### PR TITLE
Upgrade to play 2.5.4, play-slick 2.0.0

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -1,15 +1,18 @@
 package controllers
 
-import model.{User, UserForm}
+import javax.inject._
+
+import models.{User, UserForm}
 import play.api.mvc._
 import scala.concurrent.Future
 import service.UserService
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ApplicationController extends Controller {
+@Singleton
+class ApplicationController @Inject()(userService: UserService) extends Controller {
 
   def index = Action.async { implicit request =>
-    UserService.listAllUsers map { users =>
+    userService.listAllUsers map { users =>
       Ok(views.html.index(UserForm.form, users))
     }
   }
@@ -20,14 +23,14 @@ class ApplicationController extends Controller {
       errorForm => Future.successful(Ok(views.html.index(errorForm, Seq.empty[User]))),
       data => {
         val newUser = User(0, data.firstName, data.lastName, data.mobile, data.email)
-        UserService.addUser(newUser).map(res =>
+        userService.addUser(newUser).map(res =>
           Redirect(routes.ApplicationController.index())
         )
       })
   }
 
   def deleteUser(id: Long) = Action.async { implicit request =>
-    UserService.deleteUser(id) map { res =>
+    userService.deleteUser(id) map { res =>
       Redirect(routes.ApplicationController.index())
     }
   }

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -1,23 +1,26 @@
 package service
 
-import model.{User, Users}
+import javax.inject._
+
+import models.{User, Users}
 import scala.concurrent.Future
 
-object UserService {
+@Singleton
+class UserService @Inject()(users: Users) {
 
   def addUser(user: User): Future[String] = {
-    Users.add(user)
+    users.add(user)
   }
 
   def deleteUser(id: Long): Future[Int] = {
-    Users.delete(id)
+    users.delete(id)
   }
 
   def getUser(id: Long): Future[Option[User]] = {
-    Users.get(id)
+    users.get(id)
   }
 
   def listAllUsers: Future[Seq[User]] = {
-    Users.listAll
+    users.listAll
   }
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@(userForm: Form[model.UserFormData],users : Seq[model.User])(implicit request: RequestHeader)
+@(userForm: Form[models.UserFormData],users : Seq[models.User])(implicit request: RequestHeader)
 @main() {
 
     <form id="user-data-form" role="form" action='@routes.ApplicationController.addUser()' method="post" class="form-horizontal" align="center" autocomplete="off">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -4,7 +4,7 @@
 
 <html lang="en">
     <head>
-        <title>Play 2.4 + Slick 3.1.0 example</title>
+        <title>Play 2.5 + Slick 3.1.0 example</title>
         <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/favicon.png")">
         <script src="@routes.Assets.versioned("javascripts/hello.js")" type="text/javascript"></script>

--- a/build.sbt
+++ b/build.sbt
@@ -4,15 +4,15 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
   cache,
   ws,
   specs2 % Test,
-  "mysql" % "mysql-connector-java" % "5.1.34",
-  "com.typesafe.play" %% "play-slick" % "1.1.0",
-  "com.typesafe.play" %% "play-slick-evolutions" % "1.1.0"
+  "mysql" % "mysql-connector-java" % "5.1.39",
+  "com.typesafe.play" %% "play-slick" % "2.0.0",
+  "com.typesafe.play" %% "play-slick-evolutions" % "2.0.0"
 )
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
     
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
 
 // web plugins
 


### PR DESCRIPTION
Upgrades the dependencies to the current versions.

In Play 2.5, `Play.current` is deprecated, so I applied the recommended "legacy" fix.

Also, a few minor style changes.
