### PR TITLE
Updated to Slick 3.1 best practices

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -1,15 +1,18 @@
 package controllers
 
-import model.{User, UserForm}
+import javax.inject._
+
+import models.{User, UserForm}
 import play.api.mvc._
 import scala.concurrent.Future
 import service.UserService
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ApplicationController extends Controller {
+@Singleton
+class ApplicationController @Inject()(userService: UserService) extends Controller {
 
   def index = Action.async { implicit request =>
-    UserService.listAllUsers map { users =>
+    userService.listAllUsers map { users =>
       Ok(views.html.index(UserForm.form, users))
     }
   }
@@ -20,14 +23,14 @@ class ApplicationController extends Controller {
       errorForm => Future.successful(Ok(views.html.index(errorForm, Seq.empty[User]))),
       data => {
         val newUser = User(0, data.firstName, data.lastName, data.mobile, data.email)
-        UserService.addUser(newUser).map(res =>
+        userService.addUser(newUser).map(res =>
           Redirect(routes.ApplicationController.index())
         )
       })
   }
 
   def deleteUser(id: Long) = Action.async { implicit request =>
-    UserService.deleteUser(id) map { res =>
+    userService.deleteUser(id) map { res =>
       Redirect(routes.ApplicationController.index())
     }
   }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -2,13 +2,9 @@ package models
 
 import javax.inject._
 
-import play.api.Play
-import play.api.Application
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.db.slick.DatabaseConfigProvider
-
-import slick.backend.DatabaseConfig
+import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import slick.driver.JdbcProfile
 import slick.driver.MySQLDriver.api._
 
@@ -44,31 +40,28 @@ class UserTableDef(tag: Tag) extends Table[User](tag, "user") {
 }
 
 @Singleton
-class Users @Inject() (appProvider: Provider[Application]) {
+class Users @Inject() (protected val dbConfigProvider: DatabaseConfigProvider) extends HasDatabaseConfigProvider[JdbcProfile] {
 
-  // This is a hack around legacy code in play-slick.
-  // c.f. https://github.com/playframework/playframework/blob/2.5.4/documentation/manual/releases/release25/migration25/Migration25.md#handling-legacy-components
-  def dbConfig(): DatabaseConfig[JdbcProfile] =
-    DatabaseConfigProvider.get[JdbcProfile](appProvider.get())
+  import driver.api._
 
   val users = TableQuery[UserTableDef]
 
   def add(user: User): Future[String] = {
-    dbConfig().db.run(users += user).map(res => "User successfully added").recover {
+    db.run(users += user).map(res => "User successfully added").recover {
       case ex: Exception => ex.getCause.getMessage
     }
   }
 
   def delete(id: Long): Future[Int] = {
-    dbConfig().db.run(users.filter(_.id === id).delete)
+    db.run(users.filter(_.id === id).delete)
   }
 
   def get(id: Long): Future[Option[User]] = {
-    dbConfig().db.run(users.filter(_.id === id).result.headOption)
+    db.run(users.filter(_.id === id).result.headOption)
   }
 
   def listAll: Future[Seq[User]] = {
-    dbConfig().db.run(users.result)
+    db.run(users.result)
   }
 
 }

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -1,23 +1,26 @@
 package service
 
-import model.{User, Users}
+import javax.inject._
+
+import models.{User, Users}
 import scala.concurrent.Future
 
-object UserService {
+@Singleton
+class UserService @Inject()(users: Users) {
 
   def addUser(user: User): Future[String] = {
-    Users.add(user)
+    users.add(user)
   }
 
   def deleteUser(id: Long): Future[Int] = {
-    Users.delete(id)
+    users.delete(id)
   }
 
   def getUser(id: Long): Future[Option[User]] = {
-    Users.get(id)
+    users.get(id)
   }
 
   def listAllUsers: Future[Seq[User]] = {
-    Users.listAll
+    users.listAll
   }
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@(userForm: Form[model.UserFormData],users : Seq[model.User])(implicit request: RequestHeader)
+@(userForm: Form[models.UserFormData],users : Seq[models.User])(implicit request: RequestHeader)
 @main() {
 
     <form id="user-data-form" role="form" action='@routes.ApplicationController.addUser()' method="post" class="form-horizontal" align="center" autocomplete="off">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -4,7 +4,7 @@
 
 <html lang="en">
     <head>
-        <title>Play 2.4 + Slick 3.1.0 example</title>
+        <title>Play 2.5 + Slick 3.1.0 example</title>
         <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/favicon.png")">
         <script src="@routes.Assets.versioned("javascripts/hello.js")" type="text/javascript"></script>

--- a/build.sbt
+++ b/build.sbt
@@ -4,15 +4,15 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
   cache,
   ws,
   specs2 % Test,
-  "mysql" % "mysql-connector-java" % "5.1.34",
-  "com.typesafe.play" %% "play-slick" % "1.1.0",
-  "com.typesafe.play" %% "play-slick-evolutions" % "1.1.0"
+  "mysql" % "mysql-connector-java" % "5.1.39",
+  "com.typesafe.play" %% "play-slick" % "2.0.0",
+  "com.typesafe.play" %% "play-slick-evolutions" % "2.0.0"
 )
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -39,7 +39,7 @@ slick.dbs.default.driver = "slick.driver.MySQLDriver$"
 slick.dbs.default.db.driver = "com.mysql.jdbc.Driver"
 slick.dbs.default.db.url = "jdbc:mysql://localhost/playScalaSlickExample"
 slick.dbs.default.db.user = "root"
-slick.dbs.default.db.password = ""
+slick.dbs.default.db.password = "parvaz"
 
 # Evolutions
 # ~~~~~

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
     
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
 
 // web plugins
 


### PR DESCRIPTION
Hi @pedrorijo91. I used this template almost a year ago when I was learning slick and it helped me lots.

Now that slick 3.1 has evolved, I wanted to contribute to update to the play-slick 3.1 best practices, since there's no need to inject a Provider[Application] when extending the trait HasDatabaseConfigProvider[JdbcProfile] and injecting an instance of DatabaseConfigProvider. The trait takes care of that for you.